### PR TITLE
Fix wildcard removal for helm downloads

### DIFF
--- a/chart-tester.sh
+++ b/chart-tester.sh
@@ -196,7 +196,7 @@ download_helm() {
   local version="$3"
 
   log "Downloading ${BLUE}$chart${NC} version ${BLUE}$version${NC}..."
-  rm -rf "$CHARTS_DIR/$chart*"
+  rm -rf $CHARTS_DIR/$chart*
   if [[ $source == oci:* ]]; then
     helm pull --untar -d $CHARTS_DIR $source/$chart --version $version
   else


### PR DESCRIPTION
## Summary
- ensure wildcards in helm download removal expand

## Testing
- `bash chart-tester.sh --help`

------
https://chatgpt.com/codex/tasks/task_b_683d59594474832b9fdb8117a494fc15